### PR TITLE
Enhancements for SQLDB360

### DIFF
--- a/sql/moat369_fc_oracle_version.sql
+++ b/sql/moat369_fc_oracle_version.sql
@@ -356,8 +356,8 @@ COL skip_cdb     new_v skip_cdb     nopri
 COL skip_noncdb  new_v skip_noncdb  nopri
 
 select
-decode('&&is_cdb.','Y','','N','--') skip_cdb,
-decode('&&is_cdb.','Y','--','N','') skip_noncdb
+decode('&&is_cdb.','Y','','N','--') skip_noncdb,
+decode('&&is_cdb.','Y','--','N','') skip_cdb
 from dual;
 
 COL skip_cdb    clear

--- a/sql/moat369_fc_oracle_version.sql
+++ b/sql/moat369_fc_oracle_version.sql
@@ -1,70 +1,133 @@
 -- Set version variables. Value will be 'Y' or 'N'
-COL is_ver_le_9_1  new_v is_ver_le_9_1  nopri
-COL is_ver_le_9_2  new_v is_ver_le_9_2  nopri
-COL is_ver_le_9    new_v is_ver_le_9    nopri
-COL is_ver_le_10_1 new_v is_ver_le_10_1 nopri
-COL is_ver_le_10_2 new_v is_ver_le_10_2 nopri
-COL is_ver_le_10   new_v is_ver_le_10   nopri
-COL is_ver_le_11_1 new_v is_ver_le_11_1 nopri
-COL is_ver_le_11_2 new_v is_ver_le_11_2 nopri
-COL is_ver_le_11   new_v is_ver_le_11   nopri
-COL is_ver_le_12_1 new_v is_ver_le_12_1 nopri
-COL is_ver_le_12_2 new_v is_ver_le_12_2 nopri
-COL is_ver_le_12   new_v is_ver_le_12   nopri
-COL is_ver_le_18   new_v is_ver_le_18   nopri
-COL is_ver_le_19   new_v is_ver_le_19   nopri
-COL is_ver_le_20   new_v is_ver_le_20   nopri
+COL is_ver_eq_9_1      new_v is_ver_eq_9_1      nopri
+COL is_ver_eq_9_2      new_v is_ver_eq_9_2      nopri
+COL is_ver_eq_9        new_v is_ver_eq_9        nopri
+COL is_ver_eq_10_1     new_v is_ver_eq_10_1     nopri
+COL is_ver_eq_10_2     new_v is_ver_eq_10_2     nopri
+COL is_ver_eq_10       new_v is_ver_eq_10       nopri
+COL is_ver_eq_11_1     new_v is_ver_eq_11_1     nopri
+COL is_ver_eq_11_2     new_v is_ver_eq_11_2     nopri
+COL is_ver_eq_11_201   new_v is_ver_eq_11_201   nopri
+COL is_ver_eq_11_203   new_v is_ver_eq_11_203   nopri
+COL is_ver_eq_11       new_v is_ver_eq_11       nopri
+COL is_ver_eq_12_1     new_v is_ver_eq_12_1     nopri
+COL is_ver_eq_12_101   new_v is_ver_eq_12_101   nopri
+COL is_ver_eq_12_2     new_v is_ver_eq_12_2     nopri
+COL is_ver_eq_12       new_v is_ver_eq_12       nopri
+COL is_ver_eq_18       new_v is_ver_eq_18       nopri
+COL is_ver_eq_19       new_v is_ver_eq_19       nopri
+COL is_ver_eq_20       new_v is_ver_eq_20       nopri
+
+COL is_ver_le_9_1      new_v is_ver_le_9_1      nopri
+COL is_ver_le_9_2      new_v is_ver_le_9_2      nopri
+COL is_ver_le_9        new_v is_ver_le_9        nopri
+COL is_ver_le_10_1     new_v is_ver_le_10_1     nopri
+COL is_ver_le_10_2     new_v is_ver_le_10_2     nopri
+COL is_ver_le_10       new_v is_ver_le_10       nopri
+COL is_ver_le_11_1     new_v is_ver_le_11_1     nopri
+COL is_ver_le_11_2     new_v is_ver_le_11_2     nopri
+COL is_ver_le_11_201   new_v is_ver_le_11_201   nopri
+COL is_ver_le_11_203   new_v is_ver_le_11_203   nopri
+COL is_ver_le_11       new_v is_ver_le_11       nopri
+COL is_ver_le_12_1     new_v is_ver_le_12_1     nopri
+COL is_ver_le_12_101   new_v is_ver_le_12_101   nopri
+COL is_ver_le_12_2     new_v is_ver_le_12_2     nopri
+COL is_ver_le_12       new_v is_ver_le_12       nopri
+COL is_ver_le_18       new_v is_ver_le_18       nopri
+COL is_ver_le_19       new_v is_ver_le_19       nopri
+COL is_ver_le_20       new_v is_ver_le_20       nopri
 --
-COL is_ver_ge_9_1  new_v is_ver_ge_9_1  nopri
-COL is_ver_ge_9_2  new_v is_ver_ge_9_2  nopri
-COL is_ver_ge_9    new_v is_ver_ge_9    nopri
-COL is_ver_ge_10_1 new_v is_ver_ge_10_1 nopri
-COL is_ver_ge_10_2 new_v is_ver_ge_10_2 nopri
-COL is_ver_ge_10   new_v is_ver_ge_10   nopri
-COL is_ver_ge_11_1 new_v is_ver_ge_11_1 nopri
-COL is_ver_ge_11_2 new_v is_ver_ge_11_2 nopri
-COL is_ver_ge_11   new_v is_ver_ge_11   nopri
-COL is_ver_ge_12_1 new_v is_ver_ge_12_1 nopri
-COL is_ver_ge_12_2 new_v is_ver_ge_12_2 nopri
-COL is_ver_ge_12   new_v is_ver_ge_12   nopri
-COL is_ver_ge_18   new_v is_ver_ge_18   nopri
-COL is_ver_ge_19   new_v is_ver_ge_19   nopri
-COL is_ver_ge_20   new_v is_ver_ge_20   nopri
+COL is_ver_ge_9_1      new_v is_ver_ge_9_1      nopri
+COL is_ver_ge_9_2      new_v is_ver_ge_9_2      nopri
+COL is_ver_ge_9        new_v is_ver_ge_9        nopri
+COL is_ver_ge_10_1     new_v is_ver_ge_10_1     nopri
+COL is_ver_ge_10_2     new_v is_ver_ge_10_2     nopri
+COL is_ver_ge_10       new_v is_ver_ge_10       nopri
+COL is_ver_ge_11_1     new_v is_ver_ge_11_1     nopri
+COL is_ver_ge_11_2     new_v is_ver_ge_11_2     nopri
+COL is_ver_ge_11       new_v is_ver_ge_11       nopri
+COL is_ver_ge_12_1     new_v is_ver_ge_12_1     nopri
+COL is_ver_ge_12_2     new_v is_ver_ge_12_2     nopri
+COL is_ver_ge_12       new_v is_ver_ge_12       nopri
+COL is_ver_ge_18       new_v is_ver_ge_18       nopri
+COL is_ver_ge_19       new_v is_ver_ge_19       nopri
+COL is_ver_ge_20       new_v is_ver_ge_20       nopri
 
 -- Set skip version variables. Value will be '--' when version is the corresponding.
-COL skip_ver_le_9_1  new_v skip_ver_le_9_1  nopri
-COL skip_ver_le_9_2  new_v skip_ver_le_9_2  nopri
-COL skip_ver_le_9    new_v skip_ver_le_9    nopri
-COL skip_ver_le_10_1 new_v skip_ver_le_10_1 nopri
-COL skip_ver_le_10_2 new_v skip_ver_le_10_2 nopri
-COL skip_ver_le_10   new_v skip_ver_le_10   nopri
-COL skip_ver_le_11_1 new_v skip_ver_le_11_1 nopri
-COL skip_ver_le_11_2 new_v skip_ver_le_11_2 nopri
-COL skip_ver_le_11   new_v skip_ver_le_11   nopri
-COL skip_ver_le_12_1 new_v skip_ver_le_12_1 nopri
-COL skip_ver_le_12_2 new_v skip_ver_le_12_2 nopri
-COL skip_ver_le_12   new_v skip_ver_le_12   nopri
-COL skip_ver_le_18   new_v skip_ver_le_18   nopri
-COL skip_ver_le_19   new_v skip_ver_le_19   nopri
-COL skip_ver_le_20   new_v skip_ver_le_20   nopri
+COL skip_ver_eq_9_1    new_v skip_ver_eq_9_1    nopri
+COL skip_ver_eq_9_2    new_v skip_ver_eq_9_2    nopri
+COL skip_ver_eq_9      new_v skip_ver_eq_9      nopri
+COL skip_ver_eq_10_1   new_v skip_ver_eq_10_1   nopri
+COL skip_ver_eq_10_2   new_v skip_ver_eq_10_2   nopri
+COL skip_ver_eq_10     new_v skip_ver_eq_10     nopri
+COL skip_ver_eq_11_1   new_v skip_ver_eq_11_1   nopri
+COL skip_ver_eq_11_2   new_v skip_ver_eq_11_2   nopri
+COL skip_ver_eq_11_201 new_v skip_ver_eq_11_201 nopri
+COL skip_ver_eq_11_203 new_v skip_ver_eq_11_203 nopri
+COL skip_ver_eq_11     new_v skip_ver_eq_11     nopri
+COL skip_ver_eq_12_1   new_v skip_ver_eq_12_1   nopri
+COL skip_ver_eq_12_101 new_v skip_ver_eq_12_101 nopri
+COL skip_ver_eq_12_2   new_v skip_ver_eq_12_2   nopri
+COL skip_ver_eq_12     new_v skip_ver_eq_12     nopri
+COL skip_ver_eq_18     new_v skip_ver_eq_18     nopri
+COL skip_ver_eq_19     new_v skip_ver_eq_19     nopri
+COL skip_ver_eq_20     new_v skip_ver_eq_20     nopri
 --
-COL skip_ver_ge_9_1  new_v skip_ver_ge_9_1  nopri
-COL skip_ver_ge_9_2  new_v skip_ver_ge_9_2  nopri
-COL skip_ver_ge_9    new_v skip_ver_ge_9    nopri
-COL skip_ver_ge_10_1 new_v skip_ver_ge_10_1 nopri
-COL skip_ver_ge_10_2 new_v skip_ver_ge_10_2 nopri
-COL skip_ver_ge_10   new_v skip_ver_ge_10   nopri
-COL skip_ver_ge_11_1 new_v skip_ver_ge_11_1 nopri
-COL skip_ver_ge_11_2 new_v skip_ver_ge_11_2 nopri
-COL skip_ver_ge_11   new_v skip_ver_ge_11   nopri
-COL skip_ver_ge_12_1 new_v skip_ver_ge_12_1 nopri
-COL skip_ver_ge_12_2 new_v skip_ver_ge_12_2 nopri
-COL skip_ver_ge_12   new_v skip_ver_ge_12   nopri
-COL skip_ver_ge_18   new_v skip_ver_ge_18   nopri
-COL skip_ver_ge_19   new_v skip_ver_ge_19   nopri
-COL skip_ver_ge_20   new_v skip_ver_ge_20   nopri
+COL skip_ver_le_9_1    new_v skip_ver_le_9_1    nopri
+COL skip_ver_le_9_2    new_v skip_ver_le_9_2    nopri
+COL skip_ver_le_9      new_v skip_ver_le_9      nopri
+COL skip_ver_le_10_1   new_v skip_ver_le_10_1   nopri
+COL skip_ver_le_10_2   new_v skip_ver_le_10_2   nopri
+COL skip_ver_le_10     new_v skip_ver_le_10     nopri
+COL skip_ver_le_11_1   new_v skip_ver_le_11_1   nopri
+COL skip_ver_le_11_2   new_v skip_ver_le_11_2   nopri
+COL skip_ver_le_11_201 new_v skip_ver_le_11_201 nopri
+COL skip_ver_le_11_203 new_v skip_ver_le_11_203 nopri
+COL skip_ver_le_11     new_v skip_ver_le_11     nopri
+COL skip_ver_le_12_1   new_v skip_ver_le_12_1   nopri
+COL skip_ver_le_12_101 new_v skip_ver_le_12_101 nopri
+COL skip_ver_le_12_2   new_v skip_ver_le_12_2   nopri
+COL skip_ver_le_12     new_v skip_ver_le_12     nopri
+COL skip_ver_le_18     new_v skip_ver_le_18     nopri
+COL skip_ver_le_19     new_v skip_ver_le_19     nopri
+COL skip_ver_le_20     new_v skip_ver_le_20     nopri
+--
+COL skip_ver_ge_9_1    new_v skip_ver_ge_9_1    nopri
+COL skip_ver_ge_9_2    new_v skip_ver_ge_9_2    nopri
+COL skip_ver_ge_9      new_v skip_ver_ge_9      nopri
+COL skip_ver_ge_10_1   new_v skip_ver_ge_10_1   nopri
+COL skip_ver_ge_10_2   new_v skip_ver_ge_10_2   nopri
+COL skip_ver_ge_10     new_v skip_ver_ge_10     nopri
+COL skip_ver_ge_11_1   new_v skip_ver_ge_11_1   nopri
+COL skip_ver_ge_11_2   new_v skip_ver_ge_11_2   nopri
+COL skip_ver_ge_11     new_v skip_ver_ge_11     nopri
+COL skip_ver_ge_12_1   new_v skip_ver_ge_12_1   nopri
+COL skip_ver_ge_12_2   new_v skip_ver_ge_12_2   nopri
+COL skip_ver_ge_12     new_v skip_ver_ge_12     nopri
+COL skip_ver_ge_18     new_v skip_ver_ge_18     nopri
+COL skip_ver_ge_19     new_v skip_ver_ge_19     nopri
+COL skip_ver_ge_20     new_v skip_ver_ge_20     nopri
 
-select -- Lower or Equal
+select -- Equal
+       case when version = 9 and release = 1                     then 'Y' else 'N' end is_ver_eq_9_1,
+       case when version = 9 and release = 2                     then 'Y' else 'N' end is_ver_eq_9_2,
+       case when version = 9                                     then 'Y' else 'N' end is_ver_eq_9,
+       case when version = 10 and release = 1                    then 'Y' else 'N' end is_ver_eq_10_1,
+       case when version = 10 and release = 2                    then 'Y' else 'N' end is_ver_eq_10_2,
+       case when version = 10                                    then 'Y' else 'N' end is_ver_eq_10,
+       case when version = 11 and release = 1                    then 'Y' else 'N' end is_ver_eq_11_1,
+       case when version = 11 and release = 2                    then 'Y' else 'N' end is_ver_eq_11_2,
+       case when version = 11 and release = 2 and component = 1  then 'Y' else 'N' end is_ver_eq_11_201,
+       case when version = 11 and release = 2 and component = 3  then 'Y' else 'N' end is_ver_eq_11_203,
+       case when version = 11                                    then 'Y' else 'N' end is_ver_eq_11,
+       case when version = 12 and release = 1                    then 'Y' else 'N' end is_ver_eq_12_1,
+       case when version = 12 and release = 1 and component = 1  then 'Y' else 'N' end is_ver_eq_12_101,
+       case when version = 12 and release = 2                    then 'Y' else 'N' end is_ver_eq_12_2,
+       case when version = 12                                    then 'Y' else 'N' end is_ver_eq_12,
+       case when version = 18                                    then 'Y' else 'N' end is_ver_eq_18,
+       case when version = 19                                    then 'Y' else 'N' end is_ver_eq_19,
+       case when version = 20                                    then 'Y' else 'N' end is_ver_eq_20,
+       -- Lower or Equal
        case when version <  9  or (version = 9 and release = 1)  then 'Y' else 'N' end is_ver_le_9_1,
        case when version <= 9                                    then 'Y' else 'N' end is_ver_le_9_2,
        case when version <= 9                                    then 'Y' else 'N' end is_ver_le_9,
@@ -73,8 +136,16 @@ select -- Lower or Equal
        case when version <= 10                                   then 'Y' else 'N' end is_ver_le_10,
        case when version <  11 or (version = 11 and release = 1) then 'Y' else 'N' end is_ver_le_11_1,
        case when version <= 11                                   then 'Y' else 'N' end is_ver_le_11_2,
+       case when version <= 11 or (version = 11 and release = 1)
+                               or (version = 11 and release = 2 and component <= 1)
+                                   							     then 'Y' else 'N' end is_ver_le_11_201,
+       case when version <= 11 or (version = 11 and release = 1)
+                               or (version = 11 and release = 2 and component <= 3)
+                                   							     then 'Y' else 'N' end is_ver_le_11_203,
        case when version <= 11                                   then 'Y' else 'N' end is_ver_le_11,
        case when version <  12 or (version = 12 and release = 1) then 'Y' else 'N' end is_ver_le_12_1,
+       case when version <= 12 or (version = 12 and release = 1 and component <= 1)
+                                   							     then 'Y' else 'N' end is_ver_le_12_101,
        case when version <= 12                                   then 'Y' else 'N' end is_ver_le_12_2,
        case when version <= 12                                   then 'Y' else 'N' end is_ver_le_12,
        case when version <= 18                                   then 'Y' else 'N' end is_ver_le_18,
@@ -96,107 +167,175 @@ select -- Lower or Equal
        case when version >= 18                                   then 'Y' else 'N' end is_ver_ge_18,
        case when version >= 19                                   then 'Y' else 'N' end is_ver_ge_19,
        case when version >= 20                                   then 'Y' else 'N' end is_ver_ge_20
-from  (select to_number(substr(version,1,instr(version,'.')-1)) version,
-              to_number(substr(version,instr(version,'.')+1, instr(version,'.',1,2)-instr(version,'.')-1)) release
-         from v$instance);
+from  (select to_number(substr(version,1,instr(version,'.')-1)) version
+       ,      to_number(substr(version,instr(version,'.')+1, instr(version,'.',1,2)-instr(version,'.')-1)) release
+       ,      to_number(substr(version,instr(version,'.',1,2)+1, instr(version,'.',1,3)-instr(version,'.',1,2)-1)) server
+       ,      to_number(substr(version,instr(version,'.',1,3)+1, instr(version,'.',1,4)-instr(version,'.',1,3)-1)) component
+       from   v$instance);
 
-select -- Lower or Equal
-       decode('&&is_ver_le_9_1.'  ,'Y','--','N','') skip_ver_le_9_1,
-       decode('&&is_ver_le_9_2.'  ,'Y','--','N','') skip_ver_le_9_2,
-       decode('&&is_ver_le_9.'    ,'Y','--','N','') skip_ver_le_9,
-       decode('&&is_ver_le_10_1.' ,'Y','--','N','') skip_ver_le_10_1,
-       decode('&&is_ver_le_10_2.' ,'Y','--','N','') skip_ver_le_10_2,
-       decode('&&is_ver_le_10.'   ,'Y','--','N','') skip_ver_le_10,
-       decode('&&is_ver_le_11_1.' ,'Y','--','N','') skip_ver_le_11_1,
-       decode('&&is_ver_le_11_2.' ,'Y','--','N','') skip_ver_le_11_2,
-       decode('&&is_ver_le_11.'   ,'Y','--','N','') skip_ver_le_11,
-       decode('&&is_ver_le_12_1.' ,'Y','--','N','') skip_ver_le_12_1,
-       decode('&&is_ver_le_12_2.' ,'Y','--','N','') skip_ver_le_12_2,
-       decode('&&is_ver_le_12.'   ,'Y','--','N','') skip_ver_le_12,
-       decode('&&is_ver_le_18.'   ,'Y','--','N','') skip_ver_le_18,
-       decode('&&is_ver_le_19.'   ,'Y','--','N','') skip_ver_le_19,
-       decode('&&is_ver_le_20.'   ,'Y','--','N','') skip_ver_le_20,
+select -- Equal
+       decode('&&is_ver_eq_9_1.'    ,'Y','--','N','') skip_ver_eq_9_1,
+       decode('&&is_ver_eq_9_2.'    ,'Y','--','N','') skip_ver_eq_9_2,
+       decode('&&is_ver_eq_9.'      ,'Y','--','N','') skip_ver_eq_9,
+       decode('&&is_ver_eq_10_1.'   ,'Y','--','N','') skip_ver_eq_10_1,
+       decode('&&is_ver_eq_10_2.'   ,'Y','--','N','') skip_ver_eq_10_2,
+       decode('&&is_ver_eq_10.'     ,'Y','--','N','') skip_ver_eq_10,
+       decode('&&is_ver_eq_11_1.'   ,'Y','--','N','') skip_ver_eq_11_1,
+       decode('&&is_ver_eq_11_2.'   ,'Y','--','N','') skip_ver_eq_11_2,
+       decode('&&is_ver_eq_11_201.' ,'Y','--','N','') skip_ver_eq_11_201,
+       decode('&&is_ver_eq_11_203.' ,'Y','--','N','') skip_ver_eq_11_203,
+       decode('&&is_ver_eq_11.'     ,'Y','--','N','') skip_ver_eq_11,
+       decode('&&is_ver_eq_12_101.' ,'Y','--','N','') skip_ver_eq_12_101,
+       decode('&&is_ver_eq_12_1.'   ,'Y','--','N','') skip_ver_eq_12_1,
+       decode('&&is_ver_eq_12_2.'   ,'Y','--','N','') skip_ver_eq_12_2,
+       decode('&&is_ver_eq_12.'     ,'Y','--','N','') skip_ver_eq_12,
+       decode('&&is_ver_eq_18.'     ,'Y','--','N','') skip_ver_eq_18,
+       decode('&&is_ver_eq_19.'     ,'Y','--','N','') skip_ver_eq_19,
+       decode('&&is_ver_eq_20.'     ,'Y','--','N','') skip_ver_eq_20,
+       -- Lower or Equal
+       decode('&&is_ver_le_9_1.'    ,'Y','--','N','') skip_ver_le_9_1,
+       decode('&&is_ver_le_9_2.'    ,'Y','--','N','') skip_ver_le_9_2,
+       decode('&&is_ver_le_9.'      ,'Y','--','N','') skip_ver_le_9,
+       decode('&&is_ver_le_10_1.'   ,'Y','--','N','') skip_ver_le_10_1,
+       decode('&&is_ver_le_10_2.'   ,'Y','--','N','') skip_ver_le_10_2,
+       decode('&&is_ver_le_10.'     ,'Y','--','N','') skip_ver_le_10,
+       decode('&&is_ver_le_11_1.'   ,'Y','--','N','') skip_ver_le_11_1,
+       decode('&&is_ver_le_11_2.'   ,'Y','--','N','') skip_ver_le_11_2,
+	   decode('&&is_ver_le_11_201.' ,'Y','--','N','') skip_ver_le_11_201,
+	   decode('&&is_ver_le_11_203.' ,'Y','--','N','') skip_ver_le_11_203,
+       decode('&&is_ver_le_11.'     ,'Y','--','N','') skip_ver_le_11,
+       decode('&&is_ver_le_12_1.'   ,'Y','--','N','') skip_ver_le_12_1,
+       decode('&&is_ver_le_12_101.' ,'Y','--','N','') skip_ver_le_12_101,
+       decode('&&is_ver_le_12_2.'   ,'Y','--','N','') skip_ver_le_12_2,
+       decode('&&is_ver_le_12.'     ,'Y','--','N','') skip_ver_le_12,
+       decode('&&is_ver_le_18.'     ,'Y','--','N','') skip_ver_le_18,
+       decode('&&is_ver_le_19.'     ,'Y','--','N','') skip_ver_le_19,
+       decode('&&is_ver_le_20.'     ,'Y','--','N','') skip_ver_le_20,
        -- Greater or Equal
-       decode('&&is_ver_ge_9_1.'  ,'Y','--','N','') skip_ver_ge_9_1,
-       decode('&&is_ver_ge_9_2.'  ,'Y','--','N','') skip_ver_ge_9_2,
-       decode('&&is_ver_ge_9.'    ,'Y','--','N','') skip_ver_ge_9,
-       decode('&&is_ver_ge_10_1.' ,'Y','--','N','') skip_ver_ge_10_1,
-       decode('&&is_ver_ge_10_2.' ,'Y','--','N','') skip_ver_ge_10_2,
-       decode('&&is_ver_ge_10.'   ,'Y','--','N','') skip_ver_ge_10,
-       decode('&&is_ver_ge_11_1.' ,'Y','--','N','') skip_ver_ge_11_1,
-       decode('&&is_ver_ge_11_2.' ,'Y','--','N','') skip_ver_ge_11_2,
-       decode('&&is_ver_ge_11.'   ,'Y','--','N','') skip_ver_ge_11,
-       decode('&&is_ver_ge_12_1.' ,'Y','--','N','') skip_ver_ge_12_1,
-       decode('&&is_ver_ge_12_2.' ,'Y','--','N','') skip_ver_ge_12_2,
-       decode('&&is_ver_ge_12.'   ,'Y','--','N','') skip_ver_ge_12,
-       decode('&&is_ver_ge_18.'   ,'Y','--','N','') skip_ver_ge_18,
-       decode('&&is_ver_ge_19.'   ,'Y','--','N','') skip_ver_ge_19,
-       decode('&&is_ver_ge_20.'   ,'Y','--','N','') skip_ver_ge_20
+       decode('&&is_ver_ge_9_1.'    ,'Y','--','N','') skip_ver_ge_9_1,
+       decode('&&is_ver_ge_9_2.'    ,'Y','--','N','') skip_ver_ge_9_2,
+       decode('&&is_ver_ge_9.'      ,'Y','--','N','') skip_ver_ge_9,
+       decode('&&is_ver_ge_10_1.'   ,'Y','--','N','') skip_ver_ge_10_1,
+       decode('&&is_ver_ge_10_2.'   ,'Y','--','N','') skip_ver_ge_10_2,
+       decode('&&is_ver_ge_10.'     ,'Y','--','N','') skip_ver_ge_10,
+       decode('&&is_ver_ge_11_1.'   ,'Y','--','N','') skip_ver_ge_11_1,
+       decode('&&is_ver_ge_11_2.'   ,'Y','--','N','') skip_ver_ge_11_2,
+       decode('&&is_ver_ge_11.'     ,'Y','--','N','') skip_ver_ge_11,
+       decode('&&is_ver_ge_12_1.'   ,'Y','--','N','') skip_ver_ge_12_1,
+       decode('&&is_ver_ge_12_2.'   ,'Y','--','N','') skip_ver_ge_12_2,
+       decode('&&is_ver_ge_12.'     ,'Y','--','N','') skip_ver_ge_12,
+       decode('&&is_ver_ge_18.'     ,'Y','--','N','') skip_ver_ge_18,
+       decode('&&is_ver_ge_19.'     ,'Y','--','N','') skip_ver_ge_19,
+       decode('&&is_ver_ge_20.'     ,'Y','--','N','') skip_ver_ge_20
 from   dual;
 
-COL is_ver_le_9_1  clear
-COL is_ver_le_9_2  clear
-COL is_ver_le_9    clear
-COL is_ver_le_10_1 clear
-COL is_ver_le_10_2 clear
-COL is_ver_le_10   clear
-COL is_ver_le_11_1 clear
-COL is_ver_le_11_2 clear
-COL is_ver_le_11   clear
-COL is_ver_le_12_1 clear
-COL is_ver_le_12_2 clear
-COL is_ver_le_12   clear
-COL is_ver_le_18   clear
-COL is_ver_le_19   clear
-COL is_ver_le_20   clear
+COL is_ver_eq_9_1      clear
+COL is_ver_eq_9_2      clear
+COL is_ver_eq_9        clear
+COL is_ver_eq_10_1     clear
+COL is_ver_eq_10_2     clear
+COL is_ver_eq_10       clear
+COL is_ver_eq_11_1     clear
+COL is_ver_eq_11_2     clear
+COL is_ver_eq_11_201   clear
+COL is_ver_eq_11_203   clear
+COL is_ver_eq_11       clear
+COL is_ver_eq_12_1     clear
+COL is_ver_eq_12_101   clear
+COL is_ver_eq_12_2     clear
+COL is_ver_eq_12       clear
+COL is_ver_eq_18       clear
+COL is_ver_eq_19       clear
+COL is_ver_eq_20       clear
 --
-COL is_ver_ge_9_1  clear
-COL is_ver_ge_9_2  clear
-COL is_ver_ge_9    clear
-COL is_ver_ge_10_1 clear
-COL is_ver_ge_10_2 clear
-COL is_ver_ge_10   clear
-COL is_ver_ge_11_1 clear
-COL is_ver_ge_11_2 clear
-COL is_ver_ge_11   clear
-COL is_ver_ge_12_1 clear
-COL is_ver_ge_12_2 clear
-COL is_ver_ge_12   clear
-COL is_ver_ge_18   clear
-COL is_ver_ge_19   clear
-COL is_ver_ge_20   clear
+COL is_ver_le_9_1      clear
+COL is_ver_le_9_2      clear
+COL is_ver_le_9        clear
+COL is_ver_le_10_1     clear
+COL is_ver_le_10_2     clear
+COL is_ver_le_10       clear
+COL is_ver_le_11_1     clear
+COL is_ver_le_11_2     clear
+COL is_ver_le_11_201   clear
+COL is_ver_le_11_203   clear
+COL is_ver_le_11       clear
+COL is_ver_le_12_1     clear
+COL is_ver_le_12_101   clear
+COL is_ver_le_12_2     clear
+COL is_ver_le_12       clear
+COL is_ver_le_18       clear
+COL is_ver_le_19       clear
+COL is_ver_le_20       clear
+--
+COL is_ver_ge_9_1      clear
+COL is_ver_ge_9_2      clear
+COL is_ver_ge_9        clear
+COL is_ver_ge_10_1     clear
+COL is_ver_ge_10_2     clear
+COL is_ver_ge_10       clear
+COL is_ver_ge_11_1     clear
+COL is_ver_ge_11_2     clear
+COL is_ver_ge_11       clear
+COL is_ver_ge_12_1     clear
+COL is_ver_ge_12_2     clear
+COL is_ver_ge_12       clear
+COL is_ver_ge_18       clear
+COL is_ver_ge_19       clear
+COL is_ver_ge_20       clear
 
-COL skip_ver_le_9_1  clear
-COL skip_ver_le_9_2  clear
-COL skip_ver_le_9    clear
-COL skip_ver_le_10_1 clear
-COL skip_ver_le_10_2 clear
-COL skip_ver_le_10   clear
-COL skip_ver_le_11_1 clear
-COL skip_ver_le_11_2 clear
-COL skip_ver_le_11   clear
-COL skip_ver_le_12_1 clear
-COL skip_ver_le_12_2 clear
-COL skip_ver_le_12   clear
-COL skip_ver_le_18   clear
-COL skip_ver_le_19   clear
-COL skip_ver_le_20   clear
+COL skip_ver_eq_9_1    clear
+COL skip_ver_eq_9_2    clear
+COL skip_ver_eq_9      clear
+COL skip_ver_eq_10_1   clear
+COL skip_ver_eq_10_2   clear
+COL skip_ver_eq_10     clear
+COL skip_ver_eq_11_1   clear
+COL skip_ver_eq_11_2   clear
+COL skip_ver_eq_11_201 clear
+COL skip_ver_eq_11_203 clear
+COL skip_ver_eq_11     clear
+COL skip_ver_eq_12_1   clear
+COL skip_ver_eq_12_101 clear
+COL skip_ver_eq_12_2   clear
+COL skip_ver_eq_12     clear
+COL skip_ver_eq_18     clear
+COL skip_ver_eq_19     clear
+COL skip_ver_eq_20     clear
 --
-COL skip_ver_ge_9_1  clear
-COL skip_ver_ge_9_2  clear
-COL skip_ver_ge_9    clear
-COL skip_ver_ge_10_1 clear
-COL skip_ver_ge_10_2 clear
-COL skip_ver_ge_10   clear
-COL skip_ver_ge_11_1 clear
-COL skip_ver_ge_11_2 clear
-COL skip_ver_ge_11   clear
-COL skip_ver_ge_12_1 clear
-COL skip_ver_ge_12_2 clear
-COL skip_ver_ge_12   clear
-COL skip_ver_ge_18   clear
-COL skip_ver_ge_19   clear
-COL skip_ver_ge_20   clear
+COL skip_ver_le_9_1    clear
+COL skip_ver_le_9_2    clear
+COL skip_ver_le_9      clear
+COL skip_ver_le_10_1   clear
+COL skip_ver_le_10_2   clear
+COL skip_ver_le_10     clear
+COL skip_ver_le_11_1   clear
+COL skip_ver_le_11_2   clear
+COL skip_ver_le_11_201 clear
+COL skip_ver_le_11_203 clear
+COL skip_ver_le_11     clear
+COL skip_ver_le_12_1   clear
+COL skip_ver_le_12_101 clear
+COL skip_ver_le_12_2   clear
+COL skip_ver_le_12     clear
+COL skip_ver_le_18     clear
+COL skip_ver_le_19     clear
+COL skip_ver_le_20     clear
+--
+COL skip_ver_ge_9_1    clear
+COL skip_ver_ge_9_2    clear
+COL skip_ver_ge_9      clear
+COL skip_ver_ge_10_1   clear
+COL skip_ver_ge_10_2   clear
+COL skip_ver_ge_10     clear
+COL skip_ver_ge_11_1   clear
+COL skip_ver_ge_11_2   clear
+COL skip_ver_ge_11     clear
+COL skip_ver_ge_12_1   clear
+COL skip_ver_ge_12_2   clear
+COL skip_ver_ge_12     clear
+COL skip_ver_ge_18     clear
+COL skip_ver_ge_19     clear
+COL skip_ver_ge_20     clear
 
 -------------------------------
 -- Set is_cdb variable. Result will be 'Y' or 'N'.

--- a/sql/moat369_fc_oracle_version.sql
+++ b/sql/moat369_fc_oracle_version.sql
@@ -12,6 +12,8 @@ COL is_ver_le_12_1 new_v is_ver_le_12_1 nopri
 COL is_ver_le_12_2 new_v is_ver_le_12_2 nopri
 COL is_ver_le_12   new_v is_ver_le_12   nopri
 COL is_ver_le_18   new_v is_ver_le_18   nopri
+COL is_ver_le_19   new_v is_ver_le_19   nopri
+COL is_ver_le_20   new_v is_ver_le_20   nopri
 --
 COL is_ver_ge_9_1  new_v is_ver_ge_9_1  nopri
 COL is_ver_ge_9_2  new_v is_ver_ge_9_2  nopri
@@ -26,6 +28,8 @@ COL is_ver_ge_12_1 new_v is_ver_ge_12_1 nopri
 COL is_ver_ge_12_2 new_v is_ver_ge_12_2 nopri
 COL is_ver_ge_12   new_v is_ver_ge_12   nopri
 COL is_ver_ge_18   new_v is_ver_ge_18   nopri
+COL is_ver_ge_19   new_v is_ver_ge_19   nopri
+COL is_ver_ge_20   new_v is_ver_ge_20   nopri
 
 -- Set skip version variables. Value will be '--' when version is the corresponding.
 COL skip_ver_le_9_1  new_v skip_ver_le_9_1  nopri
@@ -41,6 +45,8 @@ COL skip_ver_le_12_1 new_v skip_ver_le_12_1 nopri
 COL skip_ver_le_12_2 new_v skip_ver_le_12_2 nopri
 COL skip_ver_le_12   new_v skip_ver_le_12   nopri
 COL skip_ver_le_18   new_v skip_ver_le_18   nopri
+COL skip_ver_le_19   new_v skip_ver_le_19   nopri
+COL skip_ver_le_20   new_v skip_ver_le_20   nopri
 --
 COL skip_ver_ge_9_1  new_v skip_ver_ge_9_1  nopri
 COL skip_ver_ge_9_2  new_v skip_ver_ge_9_2  nopri
@@ -55,6 +61,8 @@ COL skip_ver_ge_12_1 new_v skip_ver_ge_12_1 nopri
 COL skip_ver_ge_12_2 new_v skip_ver_ge_12_2 nopri
 COL skip_ver_ge_12   new_v skip_ver_ge_12   nopri
 COL skip_ver_ge_18   new_v skip_ver_ge_18   nopri
+COL skip_ver_ge_19   new_v skip_ver_ge_19   nopri
+COL skip_ver_ge_20   new_v skip_ver_ge_20   nopri
 
 select -- Lower or Equal
        case when version <  9  or (version = 9 and release = 1)  then 'Y' else 'N' end is_ver_le_9_1,
@@ -70,6 +78,8 @@ select -- Lower or Equal
        case when version <= 12                                   then 'Y' else 'N' end is_ver_le_12_2,
        case when version <= 12                                   then 'Y' else 'N' end is_ver_le_12,
        case when version <= 18                                   then 'Y' else 'N' end is_ver_le_18,
+       case when version <= 19                                   then 'Y' else 'N' end is_ver_le_19,
+       case when version <= 20                                   then 'Y' else 'N' end is_ver_le_20,
        -- Greater or Equal
        case when version >= 9                                    then 'Y' else 'N' end is_ver_ge_9_1,
        case when version >  9  or (version = 9 and release = 2)  then 'Y' else 'N' end is_ver_ge_9_2,
@@ -84,6 +94,8 @@ select -- Lower or Equal
        case when version >  12 or (version = 12 and release = 2) then 'Y' else 'N' end is_ver_ge_12_2,
        case when version >= 12                                   then 'Y' else 'N' end is_ver_ge_12,
        case when version >= 18                                   then 'Y' else 'N' end is_ver_ge_18
+       case when version >= 19                                   then 'Y' else 'N' end is_ver_ge_19
+       case when version >= 20                                   then 'Y' else 'N' end is_ver_ge_20
 from  (select to_number(substr(version,1,instr(version,'.')-1)) version,
               to_number(substr(version,instr(version,'.')+1, instr(version,'.',1,2)-instr(version,'.')-1)) release
          from v$instance);
@@ -102,6 +114,8 @@ select -- Lower or Equal
        decode('&&is_ver_le_12_2.' ,'Y','--','N','') skip_ver_le_12_2,
        decode('&&is_ver_le_12.'   ,'Y','--','N','') skip_ver_le_12,
        decode('&&is_ver_le_18.'   ,'Y','--','N','') skip_ver_le_18,
+       decode('&&is_ver_le_19.'   ,'Y','--','N','') skip_ver_le_19,
+       decode('&&is_ver_le_20.'   ,'Y','--','N','') skip_ver_le_20,
        -- Greater or Equal
        decode('&&is_ver_ge_9_1.'  ,'Y','--','N','') skip_ver_ge_9_1,
        decode('&&is_ver_ge_9_2.'  ,'Y','--','N','') skip_ver_ge_9_2,
@@ -116,6 +130,8 @@ select -- Lower or Equal
        decode('&&is_ver_ge_12_2.' ,'Y','--','N','') skip_ver_ge_12_2,
        decode('&&is_ver_ge_12.'   ,'Y','--','N','') skip_ver_ge_12,
        decode('&&is_ver_ge_18.'   ,'Y','--','N','') skip_ver_ge_18
+       decode('&&is_ver_ge_19.'   ,'Y','--','N','') skip_ver_ge_19
+       decode('&&is_ver_ge_20.'   ,'Y','--','N','') skip_ver_ge_20
 from   dual;
 
 COL is_ver_le_9_1  clear
@@ -131,6 +147,8 @@ COL is_ver_le_12_1 clear
 COL is_ver_le_12_2 clear
 COL is_ver_le_12   clear
 COL is_ver_le_18   clear
+COL is_ver_le_19   clear
+COL is_ver_le_20   clear
 --
 COL is_ver_ge_9_1  clear
 COL is_ver_ge_9_2  clear
@@ -145,6 +163,8 @@ COL is_ver_ge_12_1 clear
 COL is_ver_ge_12_2 clear
 COL is_ver_ge_12   clear
 COL is_ver_ge_18   clear
+COL is_ver_ge_19   clear
+COL is_ver_ge_20   clear
 
 COL skip_ver_le_9_1  clear
 COL skip_ver_le_9_2  clear
@@ -159,6 +179,8 @@ COL skip_ver_le_12_1 clear
 COL skip_ver_le_12_2 clear
 COL skip_ver_le_12   clear
 COL skip_ver_le_18   clear
+COL skip_ver_le_19   clear
+COL skip_ver_le_20   clear
 --
 COL skip_ver_ge_9_1  clear
 COL skip_ver_ge_9_2  clear
@@ -173,6 +195,8 @@ COL skip_ver_ge_12_1 clear
 COL skip_ver_ge_12_2 clear
 COL skip_ver_ge_12   clear
 COL skip_ver_ge_18   clear
+COL skip_ver_ge_19   clear
+COL skip_ver_ge_20   clear
 
 -------------------------------
 -- Set is_cdb variable. Result will be 'Y' or 'N'.

--- a/sql/moat369_fc_oracle_version.sql
+++ b/sql/moat369_fc_oracle_version.sql
@@ -93,8 +93,8 @@ select -- Lower or Equal
        case when version >= 12                                   then 'Y' else 'N' end is_ver_ge_12_1,
        case when version >  12 or (version = 12 and release = 2) then 'Y' else 'N' end is_ver_ge_12_2,
        case when version >= 12                                   then 'Y' else 'N' end is_ver_ge_12,
-       case when version >= 18                                   then 'Y' else 'N' end is_ver_ge_18
-       case when version >= 19                                   then 'Y' else 'N' end is_ver_ge_19
+       case when version >= 18                                   then 'Y' else 'N' end is_ver_ge_18,
+       case when version >= 19                                   then 'Y' else 'N' end is_ver_ge_19,
        case when version >= 20                                   then 'Y' else 'N' end is_ver_ge_20
 from  (select to_number(substr(version,1,instr(version,'.')-1)) version,
               to_number(substr(version,instr(version,'.')+1, instr(version,'.',1,2)-instr(version,'.')-1)) release
@@ -129,8 +129,8 @@ select -- Lower or Equal
        decode('&&is_ver_ge_12_1.' ,'Y','--','N','') skip_ver_ge_12_1,
        decode('&&is_ver_ge_12_2.' ,'Y','--','N','') skip_ver_ge_12_2,
        decode('&&is_ver_ge_12.'   ,'Y','--','N','') skip_ver_ge_12,
-       decode('&&is_ver_ge_18.'   ,'Y','--','N','') skip_ver_ge_18
-       decode('&&is_ver_ge_19.'   ,'Y','--','N','') skip_ver_ge_19
+       decode('&&is_ver_ge_18.'   ,'Y','--','N','') skip_ver_ge_18,
+       decode('&&is_ver_ge_19.'   ,'Y','--','N','') skip_ver_ge_19,
        decode('&&is_ver_ge_20.'   ,'Y','--','N','') skip_ver_ge_20
 from   dual;
 


### PR DESCRIPTION
There is an outstanding enhancement request from Mauro for SQLD360 to introduce skip <= >= version instead of having an ever-extending string of 'skip when = version' variables.  MOAT369 has already solved this problem, so I have introduced moat369_fc_oracle_version.sql into SQLD360, but I have also had to add additional variables for addition versions, and certain 11g and 12g patches.