### PR TITLE
Adjustments required for Solaris x86-64 compatibility

### DIFF
--- a/js/style.css
+++ b/js/style.css
@@ -3,9 +3,9 @@ h1               {font-size:16pt; font-weight:bold; color:#336699; border-bottom
 h2               {font-size:14pt; font-weight:bold; color:#336699; margin-top:4pt; margin-bottom:0pt;}
 h3               {font-size:12pt; font-weight:bold; color:#336699; margin-top:4pt; margin-bottom:0pt;}
 pre              {font:8pt monospace,Monaco,"Courier New",Courier;}
-a                {color:#663300;}
+a                {color:inherit;}
 table            {font-size:8pt; border-collapse:collapse; empty-cells:show; white-space:nowrap; border:1px solid #336699;}
-li               {font-size:8pt; color:black; padding-left:4px; padding-right:4px; padding-bottom:2px;}
+li               {font-size:8pt; padding-left:4px; padding-right:4px; padding-bottom:2px;}
 th               {font-weight:bold; color:white; background:#0066CC; padding-left:4px; padding-right:4px; padding-bottom:2px;}
 tr               {color:black; background:white;}
 tr:hover         {color:white; background:#0066CC;}

--- a/sql/moat369_0b_pre.sql
+++ b/sql/moat369_0b_pre.sql
@@ -6,8 +6,8 @@ SET FEED OFF
 SET ECHO OFF
 SET TIM OFF
 SET TIMI OFF
-DEF moat369_fw_vYYNN = 'v2010'
-DEF moat369_fw_vrsn  = '&&moat369_fw_vYYNN. (2020-10-23)'
+DEF moat369_fw_vYYNN = 'v2101'
+DEF moat369_fw_vrsn  = '&&moat369_fw_vYYNN. (2021-01-05)'
 
 -- Define all functions and files:
 @@moat369_fc_define_files.sql

--- a/sql/moat369_0b_pre.sql
+++ b/sql/moat369_0b_pre.sql
@@ -6,8 +6,8 @@ SET FEED OFF
 SET ECHO OFF
 SET TIM OFF
 SET TIMI OFF
-DEF moat369_fw_vYYNN = 'v2008'
-DEF moat369_fw_vrsn  = '&&moat369_fw_vYYNN. (2020-08-13)'
+DEF moat369_fw_vYYNN = 'v2010'
+DEF moat369_fw_vrsn  = '&&moat369_fw_vYYNN. (2020-10-23)'
 
 -- Define all functions and files:
 @@moat369_fc_define_files.sql
@@ -429,6 +429,11 @@ HOS &&cmd_getcpu. > &&moat369_cpuinfo.
 
 -- initialization
 COL row_num NEW_V row_num HEA '#' PRI
+
+-- main report dynamic link color variables
+COL color_start NEW_V color_start NOPRI
+COL color_end   NEW_V color_end   NOPRI
+COL report_link NEW_V report_link NOPRI
 
 -- get average number of CPUs
 COL avg_cpu_count NEW_V avg_cpu_count FOR A6;

--- a/sql/moat369_0b_pre.sql
+++ b/sql/moat369_0b_pre.sql
@@ -6,8 +6,8 @@ SET FEED OFF
 SET ECHO OFF
 SET TIM OFF
 SET TIMI OFF
-DEF moat369_fw_vYYNN = 'v2002'
-DEF moat369_fw_vrsn  = '&&moat369_fw_vYYNN. (2020-02-27)'
+DEF moat369_fw_vYYNN = 'v2008'
+DEF moat369_fw_vrsn  = '&&moat369_fw_vYYNN. (2020-08-13)'
 
 -- Define all functions and files:
 @@moat369_fc_define_files.sql
@@ -172,7 +172,7 @@ COL fc_convert_txt_to_html clear
 @@&&fc_def_empty_var. moat369_pre_sw_key_file
 @@&&fc_def_output_file. enc_key_file 'key.bin'
 @@&&fc_set_value_var_nvl. 'enc_key_file' '&&moat369_pre_sw_key_file.' '&&enc_key_file.'
- 
+
 
 HOS if [ ! -f &&enc_key_file. -a '&&moat369_conf_encrypt_html.' == 'ON' ]; then openssl rand -base64 32 -out &&enc_key_file.; fi
 HOS if [ -f &&enc_key_file. ]; then openssl rsautl -encrypt -inkey &&moat369_enc_pub_file. -certin -in &&enc_key_file. -out &&enc_key_file..enc; fi
@@ -188,12 +188,14 @@ SELECT bin_prefix1 || 'awk'  cmd_awk,
 from (
 SELECT
 decode(platform_id,
-1,'/usr/xpg4/bin/', -- Solaris[tm] OE (32-bit)
-2,'/usr/xpg4/bin/', -- Solaris[tm] OE (64-bit)
+1,'/usr/xpg4/bin/',  -- Solaris[tm] OE (32-bit)
+2,'/usr/xpg4/bin/',  -- Solaris[tm] OE (64-bit)
+20,'/usr/xpg4/bin/', -- Solaris Operating System (x86-64)
 '') bin_prefix1,
 decode(platform_id,
-1,'/usr/gnu/bin/', -- Solaris[tm] OE (32-bit)
-2,'/usr/gnu/bin/', -- Solaris[tm] OE (64-bit)
+1,'/usr/gnu/bin/',  -- Solaris[tm] OE (32-bit)
+2,'/usr/gnu/bin/',  -- Solaris[tm] OE (64-bit)
+20,'/usr/gnu/bin/', -- Solaris Operating System (x86-64)
 '') bin_prefix2 from v$database);
 COL cmd_awk  NEW_V clear
 COL cmd_grep NEW_V clear
@@ -414,6 +416,7 @@ SELECT decode(platform_id,
 6,'lsconf | grep Processor', -- AIX-Based Systems (64-bit)
 2,'psrinfo -v', -- Solaris[tm] OE (64-bit)
 4,'machinfo', -- HP-UX IA (64-bit)
+20,'/usr/sbin/psrinfo -v', -- Solaris Operating System (x86-64)
 'cat /proc/cpuinfo | grep -i name | sort | uniq' -- Others
 ) cmd_getcpu from v$database;
 COL cmd_getcpu clear

--- a/sql/moat369_0c_post.sql
+++ b/sql/moat369_0c_post.sql
@@ -60,8 +60,8 @@ HOS if [ '&&moat369_d3_usage.' == 'Y' ]; then zip -j &&moat369_zip_filename. &&m
 
 @@&&fc_def_empty_var. moat369_tf_usage
 @@&&fc_clean_file_name. "moat369_log3" "moat369_log3_nopath" "PATH"
---HOS if [ '&&moat369_tf_usage.' == 'Y' ]; then cp -av &&moat369_fdr_js./tablefilter/ &&moat369_sw_output_fdr./ >> &&moat369_log3.; cd &&moat369_sw_output_fdr./; zip -rm &&moat369_zip_filename_nopath. tablefilter/ >> &&moat369_log3_nopath.; fi 
-HOS if [ '&&moat369_tf_usage.' == 'Y' ]; then v_zipfdr=$(dirname "&&moat369_zip_filename."); cp -av &&moat369_fdr_js./tablefilter/ &&moat369_sw_output_fdr./ >> &&moat369_log3.; cd &&moat369_sw_output_fdr./; zip -rm $(cd - >/dev/null; cd "${v_zipfdr}"; pwd)/&&moat369_zip_filename_nopath. tablefilter/ >> &&moat369_log3_nopath.; fi 
+--HOS if [ '&&moat369_tf_usage.' == 'Y' ]; then cp -R &&moat369_fdr_js./tablefilter/ &&moat369_sw_output_fdr./ >> &&moat369_log3.; cd &&moat369_sw_output_fdr./; zip -rm &&moat369_zip_filename_nopath. tablefilter/ >> &&moat369_log3_nopath.; fi 
+HOS if [ '&&moat369_tf_usage.' == 'Y' ]; then v_zipfdr=$(dirname "&&moat369_zip_filename."); cp -R &&moat369_fdr_js./tablefilter/ &&moat369_sw_output_fdr./ >> &&moat369_log3.; cd &&moat369_sw_output_fdr./; zip -rm $(cd - >/dev/null; cd "${v_zipfdr}"; pwd)/&&moat369_zip_filename_nopath. tablefilter/ >> &&moat369_log3_nopath.; fi 
 -- Fix above cmd as cur folder can be RO
 
 HOS if [ -z '&&moat369_pre_sw_key_file.' ]; then rm -f &&enc_key_file.; fi

--- a/sql/moat369_0j_html_topic_intro.sql
+++ b/sql/moat369_0j_html_topic_intro.sql
@@ -14,11 +14,12 @@ SPO OFF
 @@&&fc_spool_end.
 
 -- update main report
-@@&&fc_spool_start.
-SPO &&moat369_main_report. APP
-PRO <a href="&&0j_param1.">&&0j_param2.</a>
-SPO OFF
-@@&&fc_spool_end.
+--@@&&fc_spool_start.
+--SPO &&moat369_main_report. APP
+--PRO <a href="&&0j_param1.">&&0j_param2.</a>
+--SPO OFF
+--@@&&fc_spool_end.
+SELECT '&&report_link. <a href="&&0j_param1.">&&0j_param2.</a>' report_link FROM DUAL;
 
 -- get time t0
 EXEC :get_time_t0 := DBMS_UTILITY.get_time;

--- a/sql/moat369_9a_pre_one.sql
+++ b/sql/moat369_9a_pre_one.sql
@@ -88,12 +88,6 @@ SPO OFF
 @@&&fc_spool_end.
 SET HEA ON
 
--- update main report
-SPO &&moat369_main_report. APP
-PRO <li title="&&main_table.">&&title.
-SPO OFF
-HOS zip -j &&moat369_zip_filename. &&moat369_main_report. >> &&moat369_log3.
-
 -- Check SQL format and highlight
 @@&&fc_set_value_var_decode. sql_hl     &&moat369_conf_sql_highlight. 'N' 'N' &&sql_hl.
 @@&&fc_set_value_var_decode. sql_format &&moat369_conf_sql_format.    'N' 'N' &&sql_format.
@@ -113,6 +107,7 @@ HOS zip -j &&moat369_zip_filename. &&moat369_main_report. >> &&moat369_log3.
 @@&&fc_set_value_var_nvl2. skip_html_file  '&&skip_html_file.'  '&&fc_skip_script.' ''
 
 -- execute one sql
+SELECT '' report_link FROM dual;
 @@&&skip_html.&&moat369_skip_html.moat369_9b_one_html.sql
 @@&&skip_text.&&moat369_skip_text.moat369_9c_one_text.sql
 @@&&skip_csv.&&moat369_skip_csv.moat369_9d_one_csv.sql
@@ -166,10 +161,19 @@ PRO &&row_num. rows selected.
 SPO OFF
 @@&&fc_set_term_off.
 
+SELECT CASE
+          WHEN &&row_num.=0  THEN '<span style="color:&&moat369_conf_list_norows_color.;">'
+          WHEN &&row_num.=-1 THEN '<span style="color:&&moat369_conf_list_error_color.;">'
+          ELSE                    '<span style="color:&&moat369_conf_list_rows_color.;">'
+       END color_start,
+       '</span>' color_end
+  FROM DUAL;
+
 -- update main report
-@@&&fc_spool_start.
 SPO &&moat369_main_report. APP
-PRO <small><em> (&&row_num.)</em></small>
+PRO &&color_start.<li title="&&main_table.">&&title.&&color_end.
+PRO &&report_link.
+PRO <small><em>&&color_start. (&&row_num.)&&color_end.</em></small>
 PRO </li>
 SPO OFF
 @@&&fc_spool_end.

--- a/sql/moat369_9c_one_text.sql
+++ b/sql/moat369_9c_one_text.sql
@@ -12,9 +12,10 @@ SPO OFF
 @@&&fc_set_term_off.
 
 -- update main report
-SPO &&moat369_main_report. APP;
-PRO <a href="&&one_spool_filename..txt">text</a>
-SPO OFF;
+--SPO &&moat369_main_report. APP;
+--PRO <a href="&&one_spool_filename..txt">text</a>
+--SPO OFF;
+SELECT '&&report_link. <a href="&&one_spool_filename..txt">text</a>' report_link FROM DUAL;
 
 -- get time t0
 EXEC :get_time_t0 := DBMS_UTILITY.get_time;

--- a/sql/moat369_9d_one_csv.sql
+++ b/sql/moat369_9d_one_csv.sql
@@ -12,9 +12,10 @@ SPO OFF;
 @@&&fc_set_term_off.
 
 -- update main report
-SPO &&moat369_main_report. APP;
-PRO <a href="&&one_spool_filename..csv">csv</a>
-SPO OFF;
+--SPO &&moat369_main_report. APP;
+--PRO <a href="&&one_spool_filename..csv">csv</a>
+--SPO OFF;
+SELECT '&&report_link. <a href="&&one_spool_filename..csv">csv</a>' report_link FROM DUAL;
 
 -- get time t0
 EXEC :get_time_t0 := DBMS_UTILITY.get_time;

--- a/sql/moat369_9f_one_text_file.sql
+++ b/sql/moat369_9f_one_text_file.sql
@@ -82,11 +82,12 @@ select substr(word,1,instr(word,'/',-1)) PATH, substr(word,instr(word,'/',-1)+1)
 from (select '&&one_spool_fullpath_filename.' word from dual));
 
 -- update main report
-@@&&fc_spool_start.
-SPO &&moat369_main_report. APP;
-PRO <a href="&&one_spool_filename.">&&one_spool_text_file_type.</a>
-SPO OFF;
-@@&&fc_spool_end.
+--@@&&fc_spool_start.
+--SPO &&moat369_main_report. APP;
+--PRO <a href="&&one_spool_filename.">&&one_spool_text_file_type.</a>
+--SPO OFF;
+--@@&&fc_spool_end.
+SELECT '&&report_link. <a href="&&one_spool_filename.">&&one_spool_text_file_type.</a>' report_link FROM DUAL;
 
 HOS if [ '&&one_spool_text_file_rename.' == 'Y' ]; then zip -mj &&moat369_zip_filename. &&one_spool_fullpath_filename. >> &&moat369_log3.; fi
 

--- a/sql/moat369_fc_check_config.sql
+++ b/sql/moat369_fc_check_config.sql
@@ -255,3 +255,17 @@
 @@&&fc_def_empty_var.      moat369_sw_desc_linesize
 @@&&fc_set_value_var_nvl. 'moat369_sw_desc_linesize'  '&&moat369_sw_desc_linesize.'  '80'
 @@&&fc_validate_variable.  moat369_sw_desc_linesize   IS_NUMBER
+
+---------------------------
+
+@@&&fc_def_empty_var. moat369_conf_list_rows_color
+@@&&fc_def_empty_var. moat369_conf_list_norows_color
+@@&&fc_def_empty_var. moat369_conf_list_error_color
+
+@@&&fc_set_value_var_nvl. 'moat369_conf_list_rows_color'   '&&moat369_conf_list_rows_color.'   'Black'
+@@&&fc_set_value_var_nvl. 'moat369_conf_list_norows_color' '&&moat369_conf_list_norows_color.' 'LightGrey'
+@@&&fc_set_value_var_nvl. 'moat369_conf_list_error_color'  '&&moat369_conf_list_error_color.'  'LightBlue'
+
+--@@&&fc_validate_variable. moat369_conf_list_rows_color   NOT_NULL
+--@@&&fc_validate_variable. moat369_conf_list_norows_color NOT_NULL
+--@@&&fc_validate_variable. moat369_conf_list_error_color  NOT_NULL

--- a/sql/moat369_fc_oracle_version.sql
+++ b/sql/moat369_fc_oracle_version.sql
@@ -177,15 +177,12 @@ COL skip_ver_ge_18   clear
 -------------------------------
 -- Set is_cdb variable. Result will be 'Y' or 'N'.
 
-COL is_cdb_temp_col new_v is_cdb_temp_col nopri
-select DECODE('&&is_ver_ge_12.','Y','CDB','''N''') is_cdb_temp_col from dual;
-COL is_cdb_temp_col clear
-
 COL is_cdb new_v is_cdb nopri
-select substr(&&is_cdb_temp_col.,1,1) is_cdb from v$database;
+select
+&&skip_ver_le_11. case when SYS_CONTEXT('USERENV','CON_ID') > 2 THEN 'N' ELSE 'Y' END is_cdb
+&&skip_ver_ge_12. 'N' is_cdb
+from dual;
 COL is_cdb new_v clear
-
-UNDEF is_cdb_temp_col
 
 -------------------------------
 


### PR DESCRIPTION
Some small adjustments required for Solaris x86-64 compatibility:

1. Solaris x86 doesn't support the **-a** or **-v** arguments of the **`cp`** command - replaced with **`cp -R`**
2. Updates to bin_prefix variables based on **platform_id=20** (for Solaris x86 - see verification below)

```
SQL> select platform_id, platform_name from v$database;

PLATFORM_ID PLATFORM_NAME
----------- --------------------------------------
         20 Solaris Operating System (x86-64)

SQL>
```