### PR TITLE
Adjustments required for Solaris x86-64 compatibility

### DIFF
--- a/sql/moat369_0b_pre.sql
+++ b/sql/moat369_0b_pre.sql
@@ -188,12 +188,14 @@ SELECT bin_prefix1 || 'awk'  cmd_awk,
 from (
 SELECT
 decode(platform_id,
-1,'/usr/xpg4/bin/', -- Solaris[tm] OE (32-bit)
-2,'/usr/xpg4/bin/', -- Solaris[tm] OE (64-bit)
+1,'/usr/xpg4/bin/',  -- Solaris[tm] OE (32-bit)
+2,'/usr/xpg4/bin/',  -- Solaris[tm] OE (64-bit)
+20,'/usr/xpg4/bin/', -- Solaris Operating System (x86-64)
 '') bin_prefix1,
 decode(platform_id,
-1,'/usr/gnu/bin/', -- Solaris[tm] OE (32-bit)
-2,'/usr/gnu/bin/', -- Solaris[tm] OE (64-bit)
+1,'/usr/gnu/bin/',  -- Solaris[tm] OE (32-bit)
+2,'/usr/gnu/bin/',  -- Solaris[tm] OE (64-bit)
+20,'/usr/gnu/bin/', -- Solaris Operating System (x86-64)
 '') bin_prefix2 from v$database);
 COL cmd_awk  NEW_V clear
 COL cmd_grep NEW_V clear
@@ -414,6 +416,7 @@ SELECT decode(platform_id,
 6,'lsconf | grep Processor', -- AIX-Based Systems (64-bit)
 2,'psrinfo -v', -- Solaris[tm] OE (64-bit)
 4,'machinfo', -- HP-UX IA (64-bit)
+20,'/usr/sbin/psrinfo -v', -- Solaris Operating System (x86-64)
 'cat /proc/cpuinfo | grep -i name | sort | uniq' -- Others
 ) cmd_getcpu from v$database;
 COL cmd_getcpu clear

--- a/sql/moat369_0c_post.sql
+++ b/sql/moat369_0c_post.sql
@@ -60,8 +60,8 @@ HOS if [ '&&moat369_d3_usage.' == 'Y' ]; then zip -j &&moat369_zip_filename. &&m
 
 @@&&fc_def_empty_var. moat369_tf_usage
 @@&&fc_clean_file_name. "moat369_log3" "moat369_log3_nopath" "PATH"
---HOS if [ '&&moat369_tf_usage.' == 'Y' ]; then cp -av &&moat369_fdr_js./tablefilter/ &&moat369_sw_output_fdr./ >> &&moat369_log3.; cd &&moat369_sw_output_fdr./; zip -rm &&moat369_zip_filename_nopath. tablefilter/ >> &&moat369_log3_nopath.; fi 
-HOS if [ '&&moat369_tf_usage.' == 'Y' ]; then v_zipfdr=$(dirname "&&moat369_zip_filename."); cp -av &&moat369_fdr_js./tablefilter/ &&moat369_sw_output_fdr./ >> &&moat369_log3.; cd &&moat369_sw_output_fdr./; zip -rm $(cd - >/dev/null; cd "${v_zipfdr}"; pwd)/&&moat369_zip_filename_nopath. tablefilter/ >> &&moat369_log3_nopath.; fi 
+--HOS if [ '&&moat369_tf_usage.' == 'Y' ]; then cp -R &&moat369_fdr_js./tablefilter/ &&moat369_sw_output_fdr./ >> &&moat369_log3.; cd &&moat369_sw_output_fdr./; zip -rm &&moat369_zip_filename_nopath. tablefilter/ >> &&moat369_log3_nopath.; fi 
+HOS if [ '&&moat369_tf_usage.' == 'Y' ]; then v_zipfdr=$(dirname "&&moat369_zip_filename."); cp -R &&moat369_fdr_js./tablefilter/ &&moat369_sw_output_fdr./ >> &&moat369_log3.; cd &&moat369_sw_output_fdr./; zip -rm $(cd - >/dev/null; cd "${v_zipfdr}"; pwd)/&&moat369_zip_filename_nopath. tablefilter/ >> &&moat369_log3_nopath.; fi 
 -- Fix above cmd as cur folder can be RO
 
 HOS if [ -z '&&moat369_pre_sw_key_file.' ]; then rm -f &&enc_key_file.; fi


### PR DESCRIPTION
Some small adjustments required for Solaris x86-64 compatibility:

1. Solaris x86 doesn't support the **-a** or **-v** arguments of the **`cp`** command - replaced with **`cp -R`**
2. Updates to bin_prefix variables based on **platform_id=20** (for Solaris x86 - see verification below)

```
SQL> select platform_id, platform_name from v$database;

PLATFORM_ID PLATFORM_NAME
----------- --------------------------------------
         20 Solaris Operating System (x86-64)

SQL>
```