### PR TITLE
Adjust how the is_cdb variable value is determined

### DIFF
--- a/sql/moat369_0b_pre.sql
+++ b/sql/moat369_0b_pre.sql
@@ -7,7 +7,7 @@ SET ECHO OFF
 SET TIM OFF
 SET TIMI OFF
 DEF moat369_fw_vYYNN = 'v2101'
-DEF moat369_fw_vrsn  = '&&moat369_fw_vYYNN. (2020-01-08)'
+DEF moat369_fw_vrsn  = '&&moat369_fw_vYYNN. (2021-01-08)'
 
 -- Define all functions and files:
 @@moat369_fc_define_files.sql

--- a/sql/moat369_0b_pre.sql
+++ b/sql/moat369_0b_pre.sql
@@ -6,8 +6,8 @@ SET FEED OFF
 SET ECHO OFF
 SET TIM OFF
 SET TIMI OFF
-DEF moat369_fw_vYYNN = 'v2002'
-DEF moat369_fw_vrsn  = '&&moat369_fw_vYYNN. (2020-02-27)'
+DEF moat369_fw_vYYNN = 'v2101'
+DEF moat369_fw_vrsn  = '&&moat369_fw_vYYNN. (2020-01-08)'
 
 -- Define all functions and files:
 @@moat369_fc_define_files.sql

--- a/sql/moat369_fc_oracle_version.sql
+++ b/sql/moat369_fc_oracle_version.sql
@@ -177,15 +177,12 @@ COL skip_ver_ge_18   clear
 -------------------------------
 -- Set is_cdb variable. Result will be 'Y' or 'N'.
 
-COL is_cdb_temp_col new_v is_cdb_temp_col nopri
-select DECODE('&&is_ver_ge_12.','Y','CDB','''N''') is_cdb_temp_col from dual;
-COL is_cdb_temp_col clear
-
 COL is_cdb new_v is_cdb nopri
-select substr(&&is_cdb_temp_col.,1,1) is_cdb from v$database;
+select
+&&skip_ver_le_11. case when SYS_CONTEXT('USERENV','CON_ID') = 1 then 'Y' else 'N' end is_cdb
+&&skip_ver_ge_12. 'N' is_cdb
+from dual;
 COL is_cdb new_v clear
-
-UNDEF is_cdb_temp_col
 
 -------------------------------
 


### PR DESCRIPTION
Existing method of determining the `is_cdb` variable is simply based on essentially whether the DB version is 12c or greater. Hence the variable is effectively redundant.

It also doesn't matter as to whether the tooling is being run from a container architecture database or not - what does actually matter is whether the tooling is being run from the **CDB$ROOT container or a PDB**.

Operation from a PDB should work the same as from a non-CDB DB with respect to which views are queried. When running in a PDB queries should be against DBA_ views. Documentation reference: https://docs.oracle.com/en/database/oracle/oracle-database/21/multi/administering-a-cdb-with-sql-plus.html#GUID-D4006B79-54C7-4D43-A209-681A13C759CA

Hence changing determination of `is_cdb` to be based whether tooling is run from the **CDB$ROOT** or a **PDB/non-CDB DB**.